### PR TITLE
Move to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV USER root
 WORKDIR /go/src/github.com/docker/markdownlint
 
 RUN go get github.com/russross/blackfriday
-run go get github.com/miekg/mmark
+RUN go get github.com/miekg/mmark
 
 ADD . /go/src/github.com/docker/markdownlint
 RUN go get -d -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ RUN wget -O github-release.bz2 https://github.com/aktau/github-release/releases/
 ENV GOPATH /go
 ENV USER root
 
-WORKDIR /go/src/github.com/SvenDowideit/markdownlint
+WORKDIR /go/src/github.com/docker/markdownlint
 
 RUN go get github.com/russross/blackfriday
 run go get github.com/miekg/mmark
 
-ADD . /go/src/github.com/SvenDowideit/markdownlint
+ADD . /go/src/github.com/docker/markdownlint
 RUN go get -d -v
 RUN go test -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build -o markdownlint main.go
 
 shell: docker-build
-	docker run --rm -it -v $(CURDIR):/go/src/github.com/SvenDowideit/markdownlint markdownlint bash
+	docker run --rm -it -v $(CURDIR):/go/src/github.com/docker/markdownlint markdownlint bash
 
 docker-build:
 	rm -f markdownlint.zip
@@ -21,7 +21,7 @@ docker-build:
 docker: docker-build
 	docker rm markdownlint-build || true
 	docker run --name markdownlint-build markdownlint ls
-	docker cp markdownlint-build:/go/src/github.com/SvenDowideit/markdownlint/markdownlint.zip .
+	docker cp markdownlint-build:/go/src/github.com/docker/markdownlint/markdownlint.zip .
 	rm -f markdownlint
 	unzip -o markdownlint.zip
 

--- a/checkers/frontmatter.go
+++ b/checkers/frontmatter.go
@@ -6,8 +6,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/SvenDowideit/markdownlint/data"
-	"github.com/SvenDowideit/markdownlint/linereader"
+	"github.com/docker/markdownlint/data"
+	"github.com/docker/markdownlint/linereader"
 )
 
 // https://gohugo.io/content/front-matter/

--- a/checkers/frontmatter_test.go
+++ b/checkers/frontmatter_test.go
@@ -3,15 +3,15 @@ package checkers
 import (
 	"testing"
 
-	"github.com/SvenDowideit/markdownlint/data"
-	"github.com/SvenDowideit/markdownlint/linereader"
+	"github.com/docker/markdownlint/data"
+	"github.com/docker/markdownlint/linereader"
 )
 
 // NOTE: this has some spaces and tabs as well as newlines at the start. this is intentional
 const OK_TOPIC = `
 
-  
-	
+
+
 <!--[metadata]>
 +++
 title = "Dockerfile reference"
@@ -25,8 +25,8 @@ parent = "mn_reference"
 `
 const MISSING_COMMENT_START_TOPIC = `
 
-  
-	
+
+
 +++
 title = "Dockerfile reference"
 description = "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
@@ -39,8 +39,8 @@ parent = "mn_reference"
 `
 const MISSING_COMMENT_END_TOPIC = `
 
-  
-	
+
+
 <!--[metadata]>
 +++
 title = "Dockerfile reference end comment missing"

--- a/checkers/links.go
+++ b/checkers/links.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SvenDowideit/markdownlint/data"
-	"github.com/SvenDowideit/markdownlint/linereader"
+	"github.com/docker/markdownlint/data"
+	"github.com/docker/markdownlint/linereader"
 
 	"github.com/miekg/mmark"
 )
@@ -33,7 +33,6 @@ var skipUrls = map[string]int{
 	"https://godoc.org/github.com/docker/distribution/notifications#RequestRecord": 1,
 	"https://support.docker.com":                                                   1,
 }
-
 
 func CheckMarkdownLinks(reader *linereader.LineReader, file string) (err error) {
 	// mmark.HtmlRendererWithParameters(htmlFlags, "", "", renderParameters)

--- a/checkers/links_test.go
+++ b/checkers/links_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/SvenDowideit/markdownlint/data"
+	"github.com/docker/markdownlint/data"
 	"github.com/miekg/mmark"
 )
 

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/SvenDowideit/markdownlint/checkers"
-	"github.com/SvenDowideit/markdownlint/data"
-	"github.com/SvenDowideit/markdownlint/linereader"
+	"github.com/docker/markdownlint/checkers"
+	"github.com/docker/markdownlint/data"
+	"github.com/docker/markdownlint/linereader"
 )
 
 func main() {
@@ -63,7 +63,7 @@ func main() {
 		}
 		// fmt.Printf("opening: %s\n", file)
 		count++
-		if count % 100 == 0 {
+		if count%100 == 0 {
 			fmt.Printf("\topened %d files so far\n", count)
 		}
 


### PR DESCRIPTION
Everything was linked to `github.com/SvenDowideit/markdownlint` when this repo is about `github.com/docker/markdownlint`
This brings everything into the proper location.

Also the dockerfile always includes the `github.com/russross/blackfriday` repo, yet I can't find a reference to it in the code. How is it being used?

cc @SvenDowideit 
